### PR TITLE
Remove version specification from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   # PostgreSQL Database
   postgres:


### PR DESCRIPTION
This pull request makes a minor update to the `docker-compose.yml` file by removing the `version: '3.9'` line. This change aligns the file with newer Docker Compose recommendations, as specifying the version is no longer necessary.